### PR TITLE
Port to Linux and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,11 @@ jobs:
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          ls C:\
+          ls C:\Library
           & "${{ env.SWIFT_EXECUTABLE }}" --version
+          winget install Swift.Toolchain
+          swift --version
       - name: Resolve Package Dependencies
         run: |
           & "${{ env.SWIFT_EXECUTABLE }}" package resolve
@@ -66,7 +70,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-executable -Xlinker -lc -static
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-executable -Xlinker -lc -Xlinker -static
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
-          New-Item -Path "${{ env.SWIFT_ROOT }}" -ItemType "directory"
-          Push-Location -Path "${{ env.SWIFT_ROOT }}"
-          (New-Object System.Net.WebClient).DownloadFile("${{ env.SWIFT_URL }}", ".\installer.exe")
-          ls
-          Start-Process -Wait -FilePath ".\installer.exe" "/SILENT"
+          Install-Binary -Url "${{ env.SWIFT_URL }}" -Name "installer.exe" -ArgumentList ("-q")
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Setup Swift
         run: |
           New-Item -Path "${{ env.SWIFT_ROOT }}" -ItemType "directory"
-          (New-Object System.Net.WebClient).DownloadFile("${{ env.SWIFT_URL }}", "${{ env.SWIFT_ROOT }}\installer.exe")
           Push-Location -Path "${{ env.SWIFT_ROOT }}"
+          (New-Object System.Net.WebClient).DownloadFile("${{ env.SWIFT_URL }}", ".\installer.exe")
           ls
           Start-Process -Wait -FilePath ".\installer.exe" "/SILENT"
       - name: Resolve Package Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,23 @@ jobs:
         with:
           name: ${{ env.BINARY_NAME }}-macos-universal
           path: output/${{ env.BINARY_NAME }}
+
+  build-linux:
+    name: Build for Linux
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Resolve Package Dependencies
+        run: swift package resolve
+      - name: Build
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 Xswiftc -static-executable
+      - name: Copy Binary
+        run: |
+          mkdir output
+          cp `swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path`/${{ env.BINARY_NAME }} ./output/
+      - name: Upload Binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.BINARY_NAME }}-linux-x86_64
+          path: output/${{ env.BINARY_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,16 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
-      SWIFT_EXECUTABLE: $env:SystemDrive\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\swift.exe
+      SWIFT_EXECUTABLE: $env:SystemDrive\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swift.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          ls C:\Library\Developer\Toolchains
-          ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
-          winget install Swift.Toolchain
+          ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
+          ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin
+          & "${{ env.SWIFT_EXECUTABLE }}" --version
           swift --version
       - name: Resolve Package Dependencies
         run: |
@@ -69,7 +69,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-executable
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-stdlib
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,17 +39,17 @@ jobs:
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          "${{ env.SWIFT_EXECUTABLE }}" --version
+          & "${{ env.SWIFT_EXECUTABLE }}" --version
       - name: Resolve Package Dependencies
         run: |
-          "${{ env.SWIFT_EXECUTABLE }}" package resolve
+          & "${{ env.SWIFT_EXECUTABLE }}" package resolve
       - name: Build
         run: |
-          "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+          & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
@@ -66,7 +66,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable -Xlinker "lc -static" -v
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-executable -Xlinker -lc -static
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
-          Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe"
+          swift --version
       - name: Resolve Package Dependencies
         run: swift.exe package resolve
       - name: Build
@@ -62,7 +63,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -v
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,38 @@ jobs:
       - name: Upload Binary
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.BINARY_NAME }}-macos-universal
+          name: ${{ env.BINARY_NAME }}-${{ runner.os }}-universal
           path: output/${{ env.BINARY_NAME }}
+
+  build-windows:
+    name: Build for Windows
+    runs-on: windows-latest
+    env:
+      SWIFT_VERSION: 5.6.1
+      SWIFT_URL: https://download.swift.org/swift-${{ github.SWIFT_VERSION }}-release/windows10/swift-${{ github.SWIFT_VERSION }}-RELEASE/swift-${{ github.SWIFT_VERSION }}-RELEASE-windows10.exe
+      SWIFT_ROOT: ${{ github.workspace }}\toolchain
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Swift
+        run: |
+          New-Item -Path "${{ env.SWIFT_ROOT }}" -ItemType "directory"
+          (New-Object System.Net.WebClient).DownloadFile("${{ env.SWIFT_URL }}", "${{ env.SWIFT_ROOT }}\installer.exe")
+          Start-Process -Wait -FilePath "${{ env.SWIFT_ROOT }}\installer.exe" "/SILENT"
+      - name: Resolve Package Dependencies
+        run: swift package resolve
+      - name: Build
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+      - name: Copy Binary
+        run: |
+          New-Item -Path "output" -ItemType "directory"
+          $binPath = swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ env.BINARY_NAME }}-${{ runner.os }}-x86_64
+          path: output\${{ env.BINARY_NAME }}
 
   build-linux:
     name: Build for Linux
@@ -44,5 +74,5 @@ jobs:
       - name: Upload Binary
         uses: actions/upload-artifact@v3
         with:
-          name: ${{ env.BINARY_NAME }}-linux-x86_64
+          name: ${{ env.BINARY_NAME }}-${{ runner.os }}-x86_64
           path: output/${{ env.BINARY_NAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
+      BINARY_NAME: ingress-drone-explorer.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -45,7 +46,7 @@ jobs:
           swift package resolve
       - name: Build
         run: |
-          swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+          swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --static-swift-stdlib
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,20 +39,17 @@ jobs:
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
-          ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin
-          & "${{ env.SWIFT_EXECUTABLE }} --version"
-          swift --version
+          & "${{ env.SWIFT_EXECUTABLE }}" --version
       - name: Resolve Package Dependencies
         run: |
-          & "${{ env.SWIFT_EXECUTABLE }} package resolve"
+          & "${{ env.SWIFT_EXECUTABLE }}" package resolve
       - name: Build
         run: |
-          & "${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable"
+          & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = & "${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path"
+          $binPath = & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
@@ -69,7 +66,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -static-swift-stdlib
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,13 +32,14 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
-      SWIFT_PATH: "%SystemDrive%/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain"
+      SWIFT_PATH: "$env:SystemDrive/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          ls ${{ env.SWIFT_PATH }}
           ${{ env.SWIFT_PATH }}/swift.exe --version
       - name: Resolve Package Dependencies
         run: ${{ env.SWIFT_PATH }}/swift.exe package resolve
@@ -64,7 +65,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -Xswiftc -static-executable
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -Xswiftc -static-swift-stdlib
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.6.1
-      SWIFT_URL: https://download.swift.org/swift-${{ github.SWIFT_VERSION }}-release/windows10/swift-${{ github.SWIFT_VERSION }}-RELEASE/swift-${{ github.SWIFT_VERSION }}-RELEASE-windows10.exe
+      SWIFT_URL: https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe
       SWIFT_ROOT: ${{ github.workspace }}\toolchain
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,21 +32,22 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
+      SWIFT_PATH: %SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          swift --version
+          ${{ env.SWIFT_PATH }}/swift.exe --version
       - name: Resolve Package Dependencies
-        run: swift.exe package resolve
+        run: ${{ env.SWIFT_PATH }}/swift.exe package resolve
       - name: Build
-        run: swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+        run: ${{ env.SWIFT_PATH }}/swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = ${{ env.SWIFT_PATH }}/swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
@@ -63,7 +64,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -static-executable
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,11 @@ jobs:
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
           "${{ env.SWIFT_EXECUTABLE }}" --version
       - name: Resolve Package Dependencies
-        run: "${{ env.SWIFT_EXECUTABLE }}" package resolve
+        run: |
+          "${{ env.SWIFT_EXECUTABLE }}" package resolve
       - name: Build
-        run: "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+        run: |
+          "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
   build-windows:
     name: Build for Windows
+    if: ${{ false }}  # Disable, since Swift doesn't link runtime statically on Windows.
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Copy Binary
         run: |
           mkdir output
-          cp `swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --arch arm64 --show-bin-path`/${{ env.BINARY_NAME }} ./output/
+          cp $(swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --arch arm64 --show-bin-path)/${{ env.BINARY_NAME }} ./output/
       - name: Upload Binary
         uses: actions/upload-artifact@v3
         with:
@@ -39,6 +39,7 @@ jobs:
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
+          & "${{ env.SWIFT_EXECUTABLE }}"
           & "${{ env.SWIFT_EXECUTABLE }}" --version
       - name: Resolve Package Dependencies
         run: |
@@ -66,11 +67,11 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -static-swift-stdlib
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --static-swift-stdlib
       - name: Copy Binary
         run: |
           mkdir output
-          cp `swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path`/${{ env.BINARY_NAME }} ./output/
+          cp $(swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path)/${{ env.BINARY_NAME }} ./output/
       - name: Upload Binary
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Setup Swift
         uses: compnerd/gha-setup-swift@main
         with:
-          branch: swift-${{ SWIFT_VERSION }}-release
-          tag: ${{ SWIFT_VERSION }}-RELEASE
+          branch: swift-${{ env.SWIFT_VERSION }}-release
+          tag: ${{ env.SWIFT_VERSION }}-RELEASE
       - name: Resolve Package Dependencies
         run: |
           swift package resolve

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,8 @@ jobs:
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          ls C:\
-          ls C:\Library
-          & "${{ env.SWIFT_EXECUTABLE }}" --version
+          ls C:\Library\Developer\Toolchains
+          ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
           winget install Swift.Toolchain
           swift --version
       - name: Resolve Package Dependencies
@@ -70,7 +69,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-executable -Xlinker -lc -Xlinker -static
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,24 +32,24 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
-      SWIFT_EXECUTABLE: C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swift.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Swift
-        run: |
-          Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          ${{ env.SWIFT_EXECUTABLE }} --version
+        uses: compnerd/gha-setup-swift@main
+        with:
+          branch: swift-${{ SWIFT_VERSION }}-release
+          tag: ${{ SWIFT_VERSION }}-RELEASE
       - name: Resolve Package Dependencies
         run: |
-          ${{ env.SWIFT_EXECUTABLE }} package resolve
+          swift package resolve
       - name: Build
         run: |
-          ${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+          swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = ${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,18 +41,18 @@ jobs:
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
           ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr
           ls C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin
-          & "${{ env.SWIFT_EXECUTABLE }}" --version
+          & "${{ env.SWIFT_EXECUTABLE }} --version"
           swift --version
       - name: Resolve Package Dependencies
         run: |
-          & "${{ env.SWIFT_EXECUTABLE }}" package resolve
+          & "${{ env.SWIFT_EXECUTABLE }} package resolve"
       - name: Build
         run: |
-          & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+          & "${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable"
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = & "${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path"
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
@@ -69,7 +69,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -v -Xswiftc -static-stdlib
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           New-Item -Path "${{ env.SWIFT_ROOT }}" -ItemType "directory"
           (New-Object System.Net.WebClient).DownloadFile("${{ env.SWIFT_URL }}", "${{ env.SWIFT_ROOT }}\installer.exe")
           Push-Location -Path "${{ env.SWIFT_ROOT }}"
+          ls
           Start-Process -Wait -FilePath ".\installer.exe" "/SILENT"
       - name: Resolve Package Dependencies
         run: swift package resolve

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [ 'main' ]
-  pull_request:
-    branches: [ 'main' ]
+on: [ 'push' ]
 
 env:
   BUILD_TYPE: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,25 +32,24 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
-      SWIFT_EXECUTABLE: $env:SystemDrive\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swift.exe
+      SWIFT_EXECUTABLE: C:\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\usr\bin\swift.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          & "${{ env.SWIFT_EXECUTABLE }}"
-          & "${{ env.SWIFT_EXECUTABLE }}" --version
+          ${{ env.SWIFT_EXECUTABLE }} --version
       - name: Resolve Package Dependencies
         run: |
-          & "${{ env.SWIFT_EXECUTABLE }}" package resolve
+          ${{ env.SWIFT_EXECUTABLE }} package resolve
       - name: Build
         run: |
-          & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+          ${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = & "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = ${{ env.SWIFT_EXECUTABLE }} build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,23 +32,22 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
-      SWIFT_PATH: $env:SystemDrive\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
+      SWIFT_EXECUTABLE: $env:SystemDrive\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain\swift.exe
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
-          ls ${{ env.SWIFT_PATH }}
-          ${{ env.SWIFT_PATH }}\swift.exe --version
+          "${{ env.SWIFT_EXECUTABLE }}" --version
       - name: Resolve Package Dependencies
-        run: ${{ env.SWIFT_PATH }}\swift.exe package resolve
+        run: "${{ env.SWIFT_EXECUTABLE }}" package resolve
       - name: Build
-        run: ${{ env.SWIFT_PATH }}\swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+        run: "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = ${{ env.SWIFT_PATH }}\swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = "${{ env.SWIFT_EXECUTABLE }}" build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
@@ -65,7 +64,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable -Xlinker "lc++ -static"
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable -Xlinker "lc -static" -v
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,14 +32,12 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.6.1
-      SWIFT_URL: https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe
-      SWIFT_ROOT: ${{ github.workspace }}\toolchain
     steps:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
-          Install-Binary -Url "${{ env.SWIFT_URL }}" -Name "installer.exe" -ArgumentList ("-q")
+          Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
-      SWIFT_PATH: %SystemDrive%\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
+      SWIFT_PATH: "%SystemDrive%/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,13 @@ jobs:
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
       - name: Resolve Package Dependencies
-        run: swift package resolve
+        run: swift.exe package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+        run: swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
@@ -62,7 +62,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: windows-latest
     env:
       SWIFT_VERSION: 5.8
-      SWIFT_PATH: "$env:SystemDrive/Library/Developer/Toolchains/unknown-Asserts-development.xctoolchain"
+      SWIFT_PATH: $env:SystemDrive\Library\Developer\Toolchains\unknown-Asserts-development.xctoolchain
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -40,15 +40,15 @@ jobs:
         run: |
           Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
           ls ${{ env.SWIFT_PATH }}
-          ${{ env.SWIFT_PATH }}/swift.exe --version
+          ${{ env.SWIFT_PATH }}\swift.exe --version
       - name: Resolve Package Dependencies
-        run: ${{ env.SWIFT_PATH }}/swift.exe package resolve
+        run: ${{ env.SWIFT_PATH }}\swift.exe package resolve
       - name: Build
-        run: ${{ env.SWIFT_PATH }}/swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
+        run: ${{ env.SWIFT_PATH }}\swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           New-Item -Path "output" -ItemType "directory"
-          $binPath = ${{ env.SWIFT_PATH }}/swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
+          $binPath = ${{ env.SWIFT_PATH }}\swift.exe build -c ${{ env.BUILD_TYPE }} --arch x86_64 --show-bin-path
           Copy-Item "$binPath\${{ env.BINARY_NAME }}" -Destination ".\output"
       - name: Upload Binary
         uses: actions/upload-artifact@v3
@@ -65,7 +65,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -Xswiftc -static-swift-stdlib
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable -Xlinker "lc++ -static"
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build for Windows
     runs-on: windows-latest
     env:
-      SWIFT_VERSION: 5.6.1
+      SWIFT_VERSION: 5.8
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Swift
         run: |
-          Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe"
+          Install-Binary -Url "https://download.swift.org/swift-${{ env.SWIFT_VERSION }}-release/windows10/swift-${{ env.SWIFT_VERSION }}-RELEASE/swift-${{ env.SWIFT_VERSION }}-RELEASE-windows10.exe" -Name "installer.exe" -ArgumentList ("-q")
           swift --version
       - name: Resolve Package Dependencies
         run: swift.exe package resolve
@@ -63,7 +63,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -v
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-stdlib -static-executable
       - name: Copy Binary
         run: |
           mkdir output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
         run: |
           New-Item -Path "${{ env.SWIFT_ROOT }}" -ItemType "directory"
           (New-Object System.Net.WebClient).DownloadFile("${{ env.SWIFT_URL }}", "${{ env.SWIFT_ROOT }}\installer.exe")
-          Start-Process -Wait -FilePath "${{ env.SWIFT_ROOT }}\installer.exe" "/SILENT"
+          Push-Location -Path "${{ env.SWIFT_ROOT }}"
+          Start-Process -Wait -FilePath ".\installer.exe" "/SILENT"
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Resolve Package Dependencies
         run: swift package resolve
       - name: Build
-        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 Xswiftc -static-executable
+        run: swift build -c ${{ env.BUILD_TYPE }} --arch x86_64 -Xswiftc -static-executable
       - name: Copy Binary
         run: |
           mkdir output

--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,9 @@ let package = Package(
             name: "ingress-drone-explorer",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
+            ],
+            linkerSettings: [
+                .linkedLibrary("c -static", .when(platforms: [ .linux ]))
             ]
         ),
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,9 +15,6 @@ let package = Package(
             name: "ingress-drone-explorer",
             dependencies: [
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
-            ],
-            linkerSettings: [
-                .linkedLibrary("c -static", .when(platforms: [ .linux ]))
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The Swift implementation is slower but the code is much simpler.
 
 The CI workflow builds universal binary for macOS and x86_64 binary for Linux, the file is available as artifact.
 
+The code itself is ready for Windows, but the compiler doesn't link Swift runtime statically. So the exe is not able to run without Swift dlls, and the workflow to build for Windows is disabled.
+
 ## Build
 
 Install the latest Swift, clone the repository and simply:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ An offline CLI tool to analyze reachable Portals for Ingress Drone Mark I.
 A C++ implementation is also [available](https://github.com/lucka-me/ingress-drone-explorer-cpp).
 The Swift implementation is slower but the code is much simpler.
 
-The CI workflow builds universal binary for macOS, the file is available as artifact.
+The CI workflow builds universal binary for macOS and x86_64 binary for Linux, the file is available as artifact.
 
 ## Build
 


### PR DESCRIPTION
- Implement a replacement of `NSPredicate` for Linux and Windows
- Add workflow job to build for Linux
- Add workflow job to build for Windows, but disabled since the exe is not able to run independently